### PR TITLE
Linux: update dark brand color

### DIFF
--- a/linux/net.hhoney.candy.metainfo.xml
+++ b/linux/net.hhoney.candy.metainfo.xml
@@ -25,7 +25,7 @@
 
   <branding>
     <color type="primary" scheme_preference="light">#ffec99</color>
-    <color type="primary" scheme_preference="dark">#fe9d16</color>
+    <color type="primary" scheme_preference="dark">#a15408</color>
   </branding>
 
   <screenshots>


### PR DESCRIPTION
Annoyingly I missed this in #5; not the end of the world, but might as well get it in for the next release.